### PR TITLE
Update greenwich.lua

### DIFF
--- a/greenwich.lua
+++ b/greenwich.lua
@@ -115,7 +115,7 @@ end
 
 coroutine.wrap(
     function()
-        while true do
+        while wait(10) do
             if #queue > 0 then
                 for k, v in pairs(queue) do
                     local s, e =
@@ -127,14 +127,13 @@ coroutine.wrap(
                     if e or not s then
                         break
                     else
-                        queue = table.remove(queue, 1)
+                        queue[k] = nil
                     end
                 end
             end
-            wait(10)
         end
     end
-)
+)()
 
 -- Returning everything.
 return greenwich


### PR DESCRIPTION
You have to call the corountine.wrap or the queue won't run. and "queue = table.remove(queue, 1) for pairs doesn't loop through the table in order so it's not safe to remove the first value in the table, so it's better to use "queue[k] = nil